### PR TITLE
fix: simplify vercel.json config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,17 +1,4 @@
 {
-  "version": 2,
-  "builds": [
-    {
-      "src": "api/send-email.js",
-      "use": "@vercel/node"
-    }
-  ],
-  "rewrites": [
-    {
-      "source": "/api/send-email",
-      "destination": "/api/send-email.js"
-    }
-  ],
   "headers": [
     {
       "source": "/api/(.*)",


### PR DESCRIPTION
Remove builds and rewrites to use Vercel's auto-detection for /api routes. Fixes the warning about unused build settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)